### PR TITLE
tweaked conf.d/main - apache conf

### DIFF
--- a/conf.d/main
+++ b/conf.d/main
@@ -78,7 +78,8 @@ chown -R $SERVICE_USER:$SERVICE_USER $OPENERP_DIR
 #
 
 # Enable needed modules
-a2enmod ssl proxy_http headers rewrite		
+a2enmod proxy_http headers rewrite		
 
-# Enable sites
+# Configure sites
+a2dissite 000-default
 a2ensite odoo.conf


### PR DESCRIPTION
Looking over the code I realised why the empty 000-default apache conf site was in the overlay! After removing the blank overlay, the default conf file will need to be disabled!

Also SSL should already be enabled by default.
